### PR TITLE
Remove sanity checks

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -21,10 +21,6 @@ def create_app(profile="default"):
     except:
         pass
 
-    # Set up sanity checks.
-    from . import sanity
-    app.sanity_check_modules = [sanity]
-
     from flask_bootstrap import Bootstrap
     Bootstrap(app)
 
@@ -33,21 +29,3 @@ def create_app(profile="default"):
     init_oauth2(app)
 
     return app
-
-def check_sanity(fix=True):
-    # Global sanity checks
-    from . import sanity
-
-    sanity_check_modules = getattr(current_app,
-            'sanity_check_modules',
-            [sanity])
-    if sanity not in sanity_check_modules:
-        sanity_check_modules.append(sanity)
-
-    for mod in sanity_check_modules:
-        current_app.logger.info(
-                "Running sanity checks for {mod}".format(mod=mod))
-        for i in dir(mod):
-            item = getattr(mod,i)
-            if callable(item) and i.startswith('check'):
-                item(fix)

--- a/app/oauth2/__init__.py
+++ b/app/oauth2/__init__.py
@@ -45,8 +45,4 @@ def init_app(app):
     oauth.init_app(app)
     app.oauth_client = oauth
 
-    # Set up sanity checks.
-    from . import sanity
-    getattr(app, 'sanity_check_modules', []).append(sanity)
-
     return app

--- a/app/oauth2/sanity.py
+++ b/app/oauth2/sanity.py
@@ -1,2 +1,0 @@
-from flask import current_app
-

--- a/app/sanity.py
+++ b/app/sanity.py
@@ -1,5 +1,0 @@
-"""
-Sanity checks for the environment of this app.
-All functions starting with check_ are executed automatically.
-"""
-from flask import current_app

--- a/manage.py
+++ b/manage.py
@@ -1,17 +1,9 @@
 #!/usr/bin/env python3
 from flask_script import Manager
-from app import create_app, check_sanity
+from app import create_app
 
 app = create_app()
 manager = Manager(app)
-
-@manager.command
-def sanity():
-    """
-    Run a number of sanity checks and attempt to automatically
-    fix any inconsistencies.
-    """
-    check_sanity()
 
 if __name__ == "__main__":
     manager.run()


### PR DESCRIPTION
Since this application is supposed to be simplistic and doesn't really have any local storage, we really don't need any sanity checks for the environment. So, throw out the unnecessary cruft.